### PR TITLE
chore: disable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: weekly
-    day: tuesday
-  open-pull-requests-limit: 10
-  target-branch: 'main'


### PR DESCRIPTION
Removes .github/dependabot.yml to stop version-update PRs. Security alerts already disabled org-wide.